### PR TITLE
Fetching all pipelines bug fix

### DIFF
--- a/src/organization.js
+++ b/src/organization.js
@@ -26,8 +26,13 @@ export default function (options, utils, modules) {
       return this[$data]
     }
 
-    listPipelines (callback) {
-      utils.req('GET', `${this.baseURL}/pipelines`, null, utils.wrapResult(this[$pipeline], callback))
+    listPipelines(callback, page=1, pipelines=[]) {
+      utils.req('GET', `${this.baseURL}/pipelines/?per_page=100&page=${page}`, null, utils.wrapResult(this[$pipeline], (err, response) => {
+        pipelines = pipelines.concat(response)
+        return response.length < 100
+          ? callback(err, pipelines)
+          : this.listPipelines(callback, page + 1, pipelines)
+      }))
     }
 
     getPipeline (name, callback) {


### PR DESCRIPTION
Getting list of pipelines is one of the endpoints that supports pagination and according to [BuildKite API documentation](https://buildkite.com/docs/rest-api#pagination), it will return 30 by default and maximum 100.

This PR is trying to change the code, in the way that it will recursively get all the pipelines. 